### PR TITLE
Add inspect operators command

### DIFF
--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/index.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/index.ts
@@ -4,8 +4,7 @@ import Deploy from './deploy'
 import SetBilling from './setBilling'
 import ProposeConfig from './proposeConfig'
 import ProposeOffchainConfig from './proposeOffchainConfig'
-import Inspect from './inspection/inspect'
-import Responses from './inspection/responses'
+import Inspection from './inspection'
 import WithdrawPayment from './withdrawPayment'
 import ProposalCommands from './proposal'
 import CloseCommands from './close'
@@ -21,11 +20,10 @@ export default [
   ProposeOffchainConfig,
   OCR2InitializeFlow,
   WithdrawPayment,
-  Inspect,
-  Responses,
   WithdrawFunds,
   ...ProposalCommands,
   ...CloseCommands,
+  ...Inspection,
   makeTransferOwnershipCommand(CONTRACT_LIST.OCR_2),
   makeAcceptOwnershipCommand(CONTRACT_LIST.OCR_2),
 ]

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/inspection/index.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/inspection/index.ts
@@ -1,0 +1,5 @@
+import Inspect from './inspect'
+import Responses from './responses'
+import Operators from './operators'
+
+export default [Inspect, Responses, Operators]

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/inspection/operators.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/inspection/operators.ts
@@ -1,0 +1,120 @@
+import { InspectInstruction, instructionToInspectCommand } from '../../../abstract/inspectionWrapper'
+import { CONTRACT_LIST } from '../../../../lib/contracts'
+import { CATEGORIES } from '../../../../lib/constants'
+import { LCDClient } from '@terra-money/terra.js'
+import { getLatestOCRNewTransmissionEvents } from '../../../../lib/inspection'
+import { BN, logger } from '@chainlink/gauntlet-core/dist/utils'
+import { providerUtils } from '@chainlink/gauntlet-terra'
+import { dateFromUnix } from '../../../../lib/utils'
+
+type CommandInput = {}
+
+type ContractExpectedInfo = {
+  transmitters: string[]
+  balances: { [key: string]: string | null }
+  latestTransmissions: {
+    [key: string]: {
+      answer: string
+      timestamp: number
+    }
+  }
+}
+
+const makeInput = async (flags: any, args: string[]): Promise<CommandInput> => {
+  if (flags.input) return flags.input as CommandInput
+  return {}
+}
+
+const makeOnchainData = (provider: LCDClient) => async (
+  instructionsData: any[],
+  input: CommandInput,
+  aggregator: string,
+): Promise<ContractExpectedInfo> => {
+  const transmitters = instructionsData[0]
+
+  logger.loading('Fetching latest transmission events...')
+  const events = await getLatestOCRNewTransmissionEvents(provider, aggregator, 100)
+
+  const transmissionsPerTransmitter = events.reduce(
+    (agg, e) => {
+      const transmitter = e['wasm-new_transmission'].transmitter[0]
+      if (agg[transmitter]) return agg
+      return {
+        ...agg,
+        [transmitter]: {
+          answer: e['wasm-new_transmission'].answer[0],
+          timestamp: Number(e['wasm-new_transmission'].observations_timestamp[0]),
+        },
+      }
+    },
+    {} as {
+      [key: string]: {
+        answer: string
+        timestamp: number
+      }
+    },
+  )
+
+  logger.loading('Fetching transmitters balances...')
+  const balances: (string | null)[] = await Promise.all(
+    transmitters.addresses.map((t) => providerUtils.getBalance(provider, t)),
+  )
+
+  return {
+    transmitters: transmitters.addresses,
+    balances: balances.reduce((agg, bal, i) => ({ ...agg, [transmitters.addresses[i]]: bal }), {}),
+    latestTransmissions: transmissionsPerTransmitter,
+  }
+}
+
+const inspect = (inputData: CommandInput, onchainData: ContractExpectedInfo): boolean => {
+  const balancesMsg = Object.entries(onchainData.balances).reduce((agg, [transmitter, bal]) => {
+    return `${agg}
+      - Transmitter ${transmitter}: ${bal || 'Balance not found'}`
+  }, 'Balances:')
+
+  const transmissionsMsg = Object.entries(onchainData.latestTransmissions).reduce(
+    (agg, [transmitter, transmission]) => {
+      return `${agg}
+      - Transmitter ${transmitter} transmitted at ${dateFromUnix(transmission.timestamp)} with answer ${
+        transmission.answer
+      }`
+    },
+    'Transmissions:',
+  )
+
+  logger.info(balancesMsg)
+  logger.info(transmissionsMsg)
+
+  const notResponding = onchainData.transmitters.filter(
+    (t) => !Object.keys(onchainData.latestTransmissions).includes(t),
+  )
+
+  if (notResponding.length > 0) {
+    logger.warn(`Transmitters that did not transmit in last 100 transmissions: 
+      ${notResponding}
+    `)
+  }
+
+  return true
+}
+
+const instruction: InspectInstruction<CommandInput, ContractExpectedInfo> = {
+  command: {
+    category: CATEGORIES.OCR,
+    contract: CONTRACT_LIST.OCR_2,
+    id: 'inspect:operators',
+    examples: ['ocr2:inspect:operators <AGGREGATOR_ADDRESS>', 'ocr2:inspect:operators <AGGREGATOR_ADDRESS>'],
+  },
+  instructions: [
+    {
+      contract: 'ocr2',
+      function: 'transmitters',
+    },
+  ],
+  makeInput,
+  makeOnchainData,
+  inspect,
+}
+
+export default instructionToInspectCommand<CommandInput, ContractExpectedInfo>(instruction)

--- a/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/inspection/responses.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/commands/contracts/ocr2/inspection/responses.ts
@@ -3,7 +3,7 @@ import { InspectInstruction, instructionToInspectCommand } from '../../../abstra
 import { CONTRACT_LIST } from '../../../../lib/contracts'
 import { CATEGORIES } from '../../../../lib/constants'
 import { LCDClient } from '@terra-money/terra.js'
-import { getLatestOCRNewTransmissionEvent, RoundData } from '../../../../lib/inspection'
+import { getLatestOCRNewTransmissionEvents, RoundData } from '../../../../lib/inspection'
 import { inspection, logger } from '@chainlink/gauntlet-core/dist/utils'
 import { dateFromUnix } from '../../../../lib/utils'
 
@@ -70,7 +70,7 @@ const makeOnchainData = (provider: LCDClient) => async (
   const transmitters = instructionsData[1]
   const description = instructionsData[2]
 
-  const onchainEvent = await getLatestOCRNewTransmissionEvent(provider, aggregator)
+  const onchainEvent = await getLatestOCRNewTransmissionEvents(provider, aggregator)[0]
 
   return {
     transmitters: transmitters.addresses,

--- a/packages-ts/gauntlet-terra-contracts/src/lib/inspection.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/inspection.ts
@@ -1,6 +1,6 @@
-import { AccAddress, LCDClient } from '@terra-money/terra.js'
+import { AccAddress, EventsByType, LCDClient } from '@terra-money/terra.js'
 import { providerUtils } from '@chainlink/gauntlet-terra'
-import { getLatestContractEvent } from './utils'
+import { logger } from '@chainlink/gauntlet-core/dist/utils'
 
 export type RoundData = {
   roundId: number
@@ -21,6 +21,15 @@ export const getLatestOCRConfigEvent = async (provider: LCDClient, contract: Acc
   return setConfigTx?.logs?.[0].eventsByType['wasm-set_config']
 }
 
-export const getLatestOCRNewTransmissionEvent = async (provider: LCDClient, contract: AccAddress) => {
-  return getLatestContractEvent(provider, 'wasm-new_transmission', contract)
+export const getLatestOCRNewTransmissionEvents = async (
+  provider: LCDClient,
+  contract: AccAddress,
+  amount = 10,
+): Promise<EventsByType[]> => {
+  try {
+    return providerUtils.getLatestContractEvents(provider, 'wasm-new_transmission', contract, amount)
+  } catch (e) {
+    logger.error(`Error fetching latest transmission events: ${e.message}`)
+    return []
+  }
 }

--- a/packages-ts/gauntlet-terra-contracts/src/lib/utils.ts
+++ b/packages-ts/gauntlet-terra-contracts/src/lib/utils.ts
@@ -1,25 +1,6 @@
-import { bech32 } from 'bech32'
-import { AccAddress, LCDClient } from '@terra-money/terra.js'
-
 // TODO: This function should be transfered to gauntlet-core repo.
 export function dateFromUnix(unixTimestamp: number): Date {
   return new Date(unixTimestamp * 1000)
 }
 
-export const getLatestContractEvent = async (provider: LCDClient, event: string, contract: AccAddress) => {
-  let transmissionTx = (
-    await provider.tx.search({
-      events: [
-        {
-          key: `${event}.contract_address`,
-          value: contract,
-        },
-      ],
-      'pagination.limit': '1',
-      order_by: 'ORDER_BY_DESC',
-    })
-  ).txs
-
-  return transmissionTx[0]?.logs?.[0].eventsByType[event]
-}
 export const hexToBase64 = (s: string): string => Buffer.from(s, 'hex').toString('base64')

--- a/packages-ts/gauntlet-terra/src/lib/provider.ts
+++ b/packages-ts/gauntlet-terra/src/lib/provider.ts
@@ -1,5 +1,5 @@
 import { logger } from '@chainlink/gauntlet-core/dist/utils'
-import { LCDClient, TxInfo } from '@terra-money/terra.js'
+import { AccAddress, EventsByType, LCDClient, TxInfo } from '@terra-money/terra.js'
 
 export const filterTxsByEvent = (txs: TxInfo[], event: string): TxInfo | undefined => {
   const filteredTx = txs.filter((tx) => tx.logs?.some((log) => log.eventsByType[event]))?.[0]
@@ -29,4 +29,40 @@ export const getBlockTxs = async (provider: LCDClient, block: number, offset = 0
   }
 
   return []
+}
+
+export const getLatestContractEvents = async (
+  provider: LCDClient,
+  event: string,
+  contract: AccAddress,
+  paginationLimit = 1,
+): Promise<EventsByType[]> => {
+  const txs: TxInfo[] = (
+    await provider.tx.search({
+      events: [
+        {
+          key: `${event}.contract_address`,
+          value: contract,
+        },
+      ],
+      'pagination.limit': String(paginationLimit),
+      order_by: 'ORDER_BY_DESC',
+    })
+  ).txs
+
+  if (txs.length === 0) return []
+  const events = txs
+    .map(({ logs }) => logs?.map(({ eventsByType }) => eventsByType) || [])
+    .reduce((acc, eventsByType) => [...acc, ...eventsByType], [])
+
+  return events
+}
+
+export const getBalance = async (provider: LCDClient, address: AccAddress): Promise<string | null> => {
+  try {
+    return (await provider.bank.balance(address))[0].toString()
+  } catch (e) {
+    logger.error(`Error fetching ${address} balance: ${e.message}`)
+    return null
+  }
 }


### PR DESCRIPTION
Inspect command for operators:
- Fetch transmitters from aggregator contract
- Fetch and prompt LUNA balances for each transmitter
- Fetch last 100 transmissions. Prompt last transmission of each transmitter. Inactive transmitters are prompted