### PR TITLE
pkg/terra: cleanup for generics integration in core

### DIFF
--- a/pkg/terra/chain.go
+++ b/pkg/terra/chain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 )
 
 type ChainSet interface {
@@ -17,6 +18,7 @@ type Chain interface {
 
 	ID() string
 	Config() Config
+	UpdateConfig(*db.ChainCfg)
 	TxManager() TxManager
 	// Reader returns a new Reader. If nodeName is provided, the underlying client must use that node.
 	Reader(nodeName string) (client.Reader, error)

--- a/pkg/terra/db/db.go
+++ b/pkg/terra/db/db.go
@@ -50,7 +50,7 @@ func (c *ChainCfg) Scan(value interface{}) error {
 	return json.Unmarshal(b, c)
 }
 
-func (c ChainCfg) Value() (driver.Value, error) {
+func (c *ChainCfg) Value() (driver.Value, error) {
 	return json.Marshal(c)
 }
 


### PR DESCRIPTION
Supporting https://github.com/smartcontractkit/chainlink/pull/6591 - e2e tests are expected to fail until they are both merged.