### PR TITLE
BCI-978: Update core integration tests helper method

### DIFF
--- a/pkg/cosmos/client/client_test.go
+++ b/pkg/cosmos/client/client_test.go
@@ -167,7 +167,7 @@ func TestCosmosClient(t *testing.T) {
 		require.NoError(t, err)
 		resp, err := tc.Broadcast(txBytes, txtypes.BroadcastMode_BROADCAST_MODE_SYNC)
 		require.NoError(t, err)
-		tx, success := awaitTxCommitted(t, tc, resp.TxResponse.TxHash)
+		tx, success := AwaitTxCommitted(t, tc, resp.TxResponse.TxHash)
 		require.True(t, success)
 		require.Equal(t, types.CodeTypeOK, tx.TxResponse.Code)
 
@@ -227,7 +227,7 @@ func TestCosmosClient(t *testing.T) {
 		require.NoError(t, err)
 		resp1, err := tc.SignAndBroadcast([]sdk.Msg{rawMsg}, an, sn, gasPrices["ucosm"], accounts[0].PrivateKey, txtypes.BroadcastMode_BROADCAST_MODE_SYNC)
 		require.NoError(t, err)
-		tx1, success := awaitTxCommitted(t, tc, resp1.TxResponse.TxHash)
+		tx1, success := AwaitTxCommitted(t, tc, resp1.TxResponse.TxHash)
 		require.True(t, success)
 		require.Equal(t, types.CodeTypeOK, tx1.TxResponse.Code)
 
@@ -242,7 +242,7 @@ func TestCosmosClient(t *testing.T) {
 		require.NoError(t, err)
 		resp2, err := tc.SignAndBroadcast([]sdk.Msg{rawMsg}, an, sn, gasPrices["ucosm"], accounts[0].PrivateKey, txtypes.BroadcastMode_BROADCAST_MODE_SYNC)
 		require.NoError(t, err)
-		tx2, success := awaitTxCommitted(t, tc, resp2.TxResponse.TxHash)
+		tx2, success := AwaitTxCommitted(t, tc, resp2.TxResponse.TxHash)
 		require.True(t, success)
 		require.Equal(t, types.CodeTypeOK, tx2.TxResponse.Code)
 
@@ -345,7 +345,7 @@ func TestCosmosClient(t *testing.T) {
 
 				if tt.expCode == 0 {
 					require.NoError(t, err)
-					tx, success := awaitTxCommitted(t, tc, resp.TxResponse.TxHash)
+					tx, success := AwaitTxCommitted(t, tc, resp.TxResponse.TxHash)
 					require.True(t, success)
 					require.Equal(t, types.CodeTypeOK, tx.TxResponse.Code)
 					require.Equal(t, "", tx.TxResponse.Codespace)

--- a/pkg/cosmos/client/client_test.go
+++ b/pkg/cosmos/client/client_test.go
@@ -48,7 +48,7 @@ func TestErrMatch(t *testing.T) {
 }
 
 func TestBatchSim(t *testing.T) {
-	accounts, testdir, tendermintURL := SetupLocalCosmosNode(t, "42")
+	accounts, testdir, tendermintURL := SetupLocalCosmosNode(t, "42", "ucosm")
 
 	lggr, logs := logger.TestObserved(t, zap.WarnLevel)
 	tc, err := NewClient(
@@ -61,7 +61,7 @@ func TestBatchSim(t *testing.T) {
 		return func() { assert.Len(t, logs.TakeAll(), l) }
 	}
 
-	contract := DeployTestContract(t, tendermintURL, "42", accounts[0], accounts[0], tc, testdir, "../testdata/my_first_contract.wasm")
+	contract := DeployTestContract(t, tendermintURL, "42", "ucosm", accounts[0], accounts[0], tc, testdir, "../testdata/my_first_contract.wasm")
 	var succeed sdk.Msg = &wasmtypes.MsgExecuteContract{Sender: accounts[0].Address.String(), Contract: contract.String(), Msg: []byte(`{"reset":{"count":5}}`)}
 	var fail sdk.Msg = &wasmtypes.MsgExecuteContract{Sender: accounts[0].Address.String(), Contract: contract.String(), Msg: []byte(`{"blah":{"count":5}}`)}
 
@@ -132,8 +132,9 @@ func TestBatchSim(t *testing.T) {
 }
 
 func TestCosmosClient(t *testing.T) {
+	minGasPrice := sdk.NewDecCoinFromDec("ucosm", defaultCoin)
 	// Local only for now, could maybe run on CI if we install terrad there?
-	accounts, testdir, tendermintURL := SetupLocalCosmosNode(t, "42")
+	accounts, testdir, tendermintURL := SetupLocalCosmosNode(t, "42", "ucosm")
 	lggr := logger.Test(t)
 	tc, err := NewClient(
 		"42",
@@ -144,7 +145,7 @@ func TestCosmosClient(t *testing.T) {
 	gpe := NewFixedGasPriceEstimator(map[string]sdk.DecCoin{
 		"ucosm": sdk.NewDecCoinFromDec("ucosm", sdk.MustNewDecFromStr("0.01")),
 	})
-	contract := DeployTestContract(t, tendermintURL, "42", accounts[0], accounts[0], tc, testdir, "../testdata/my_first_contract.wasm")
+	contract := DeployTestContract(t, tendermintURL, "42", "ucosm", accounts[0], accounts[0], tc, testdir, "../testdata/my_first_contract.wasm")
 
 	t.Run("send tx between accounts", func(t *testing.T) {
 		// Assert balance before

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -38,6 +38,10 @@ var minGasPrice = sdk.NewDecCoinFromDec("ucosm", sdk.NewDecWithPrec(1, 3))
 
 // SetupLocalCosmosNode sets up a local terra node via wasmd, and returns pre-funded accounts, the test directory, and the url.
 func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, string) {
+	// change bech32 prefix from cosmos to wasmd
+	typesConfig := sdk.GetConfig()
+	typesConfig.SetBech32PrefixForAccount("wasm", "wasm"+sdk.PrefixPublic)
+
 	testdir, err := os.MkdirTemp("", "integration-test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -80,7 +84,6 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 			Mnemonic string `json:"mnemonic"`
 		}
 		require.NoError(t, json.Unmarshal(key, &k))
-		k.Address = strings.Replace(k.Address, "wasm", "cosmos", 1)
 		expAcctAddr, err3 := sdk.AccAddressFromBech32(k.Address)
 		require.NoError(t, err3)
 		privateKey, address, err4 := testutil.CreateKeyFromMnemonic(k.Mnemonic)

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -79,8 +79,8 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 			Address  string `json:"address"`
 			Mnemonic string `json:"mnemonic"`
 		}
-		t.Log(k.Address)
 		require.NoError(t, json.Unmarshal(key, &k))
+		k.Address = strings.Replace(k.Address, "wasm", "cosmos", 1)
 		expAcctAddr, err3 := sdk.AccAddressFromBech32(k.Address)
 		require.NoError(t, err3)
 		privateKey, address, err4 := testutil.CreateKeyFromMnemonic(k.Mnemonic)

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -95,9 +95,9 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 		})
 	}
 	// Stake 10 luna in first acct
-	out, err = exec.Command("wasmd", "genesis", "gentx", accounts[0].Name, "10000000ucosm", "--chain-id", chainID, "--keyring-backend", "test", "--home", testdir).CombinedOutput() //nolint:gosec
+	out, err = exec.Command("wasmd", "gentx", accounts[0].Name, "10000000ucosm", "--chain-id", chainID, "--keyring-backend", "test", "--home", testdir).CombinedOutput() //nolint:gosec
 	require.NoError(t, err, string(out))
-	out, err = exec.Command("wasmd", "genesis", "collect-gentxs", "--home", testdir).CombinedOutput()
+	out, err = exec.Command("wasmd", "collect-gentxs", "--home", testdir).CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	port := mustRandomPort()

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -79,6 +79,7 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 			Address  string `json:"address"`
 			Mnemonic string `json:"mnemonic"`
 		}
+		t.Log(k.Address)
 		require.NoError(t, json.Unmarshal(key, &k))
 		expAcctAddr, err3 := sdk.AccAddressFromBech32(k.Address)
 		require.NoError(t, err3)

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -34,10 +34,12 @@ type Account struct {
 }
 
 // 0.001
-var minGasPrice = sdk.NewDecCoinFromDec("ucosm", sdk.NewDecWithPrec(1, 3))
+var defaultCoin = sdk.NewDecWithPrec(1, 3)
 
 // SetupLocalCosmosNode sets up a local terra node via wasmd, and returns pre-funded accounts, the test directory, and the url.
-func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, string) {
+// Token name is for both staking and fee coin
+func SetupLocalCosmosNode(t *testing.T, chainID string, token string) ([]Account, string, string) {
+	minGasPrice := sdk.NewDecCoinFromDec(token, defaultCoin)
 	testdir, err := os.MkdirTemp("", "integration-test")
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -62,11 +64,12 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 	require.NoError(t, err)
 
 	genesisData := string(f)
-	// fix hardcoded token, see
+	// fix hardcoded staking/governance token, see
 	// https://github.com/CosmWasm/wasmd/blob/develop/docker/setup_wasmd.sh
 	// https://github.com/CosmWasm/wasmd/blob/develop/contrib/local/setup_wasmd.sh
-	genesisData = strings.ReplaceAll(genesisData, "\"ustake\"", "\"ucosm\"")
-	genesisData = strings.ReplaceAll(genesisData, "\"stake\"", "\"ucosm\"")
+	newStakingToken := fmt.Sprintf(`"%s"`, token)
+	genesisData = strings.ReplaceAll(genesisData, "\"ustake\"", newStakingToken)
+	genesisData = strings.ReplaceAll(genesisData, "\"stake\"", newStakingToken)
 	require.NoError(t, os.WriteFile(p, []byte(genesisData), 0600))
 
 	// Create 2 test accounts
@@ -86,7 +89,7 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 		require.NoError(t, err4)
 		require.Equal(t, expAcctAddr, address)
 		// Give it 100000000ucosm
-		out2, err2 := exec.Command("wasmd", "genesis", "add-genesis-account", k.Address, "100000000ucosm", "--home", testdir).Output() //nolint:gosec
+		out2, err2 := exec.Command("wasmd", "genesis", "add-genesis-account", k.Address, "100000000"+token, "--home", testdir).Output() //nolint:gosec
 		require.NoError(t, err2, string(out2))
 		accounts = append(accounts, Account{
 			Name:       account,
@@ -94,8 +97,8 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 			PrivateKey: privateKey,
 		})
 	}
-	// Stake 10 luna in first acct
-	out, err = exec.Command("wasmd", "gentx", accounts[0].Name, "10000000ucosm", "--chain-id", chainID, "--keyring-backend", "test", "--home", testdir).CombinedOutput() //nolint:gosec
+	// Stake 10 tokens in first acct
+	out, err = exec.Command("wasmd", "gentx", accounts[0].Name, "10000000"+token, "--chain-id", chainID, "--keyring-backend", "test", "--home", testdir).CombinedOutput() //nolint:gosec
 	require.NoError(t, err, string(out))
 	out, err = exec.Command("wasmd", "collect-gentxs", "--home", testdir).CombinedOutput()
 	require.NoError(t, err, string(out))
@@ -152,10 +155,11 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 }
 
 // DeployTestContract deploys a test contract.
-func DeployTestContract(t *testing.T, tendermintURL, chainID string, deployAccount, ownerAccount Account, tc *Client, testdir, wasmTestContractPath string) sdk.AccAddress {
+func DeployTestContract(t *testing.T, tendermintURL, chainID string, token string, deployAccount, ownerAccount Account, tc *Client, testdir, wasmTestContractPath string) sdk.AccAddress {
+	minGasPrice := sdk.NewDecCoinFromDec(token, defaultCoin)
 	//nolint:gosec
 	submitResp, err2 := exec.Command("wasmd", "tx", "wasm", "store", wasmTestContractPath, "--node", tendermintURL,
-		"--from", deployAccount.Name, "--gas", "auto", "--fees", "100000ucosm", "--gas-adjustment", "1.3", "--chain-id", chainID, "--home", testdir, "--keyring-backend", "test", "--keyring-dir", testdir, "--yes", "--output", "json").Output()
+		"--from", deployAccount.Name, "--gas", "auto", "--fees", "100000"+token, "--gas-adjustment", "1.3", "--chain-id", chainID, "--home", testdir, "--keyring-backend", "test", "--keyring-dir", testdir, "--yes", "--output", "json").Output()
 	require.NoError(t, err2, string(submitResp))
 
 	// wait for tx to be committed

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -220,7 +220,7 @@ func mustRandomPort() int {
 }
 
 // awaitTxCommitted waits for a transaction to be committed on chain and returns the tx receipt
-func awaitTxCommitted(t *testing.T, tc *Client, txHash string) (response *txtypes.GetTxResponse, success bool) {
+func AwaitTxCommitted(t *testing.T, tc *Client, txHash string) (response *txtypes.GetTxResponse, success bool) {
 	for i := 0; i < 10; i++ { // max poll attempts to wait for tx commitment
 		txReceipt, err := tc.Tx(txHash)
 		if err == nil {

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -98,9 +98,9 @@ func SetupLocalCosmosNode(t *testing.T, chainID string, token string) ([]Account
 		})
 	}
 	// Stake 10 tokens in first acct
-	out, err = exec.Command("wasmd", "gentx", accounts[0].Name, "10000000"+token, "--chain-id", chainID, "--keyring-backend", "test", "--home", testdir).CombinedOutput() //nolint:gosec
+	out, err = exec.Command("wasmd", "genesis", "gentx", accounts[0].Name, "10000000"+token, "--chain-id", chainID, "--keyring-backend", "test", "--home", testdir).CombinedOutput() //nolint:gosec
 	require.NoError(t, err, string(out))
-	out, err = exec.Command("wasmd", "collect-gentxs", "--home", testdir).CombinedOutput()
+	out, err = exec.Command("wasmd", "genesis", "collect-gentxs", "--home", testdir).CombinedOutput()
 	require.NoError(t, err, string(out))
 
 	port := mustRandomPort()

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -23,6 +23,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/pelletier/go-toml"
+	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,10 +39,7 @@ var minGasPrice = sdk.NewDecCoinFromDec("ucosm", sdk.NewDecWithPrec(1, 3))
 
 // SetupLocalCosmosNode sets up a local terra node via wasmd, and returns pre-funded accounts, the test directory, and the url.
 func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, string) {
-	// change bech32 prefix from cosmos to wasmd
-	typesConfig := sdk.GetConfig()
-	typesConfig.SetBech32PrefixForAccount("wasm", "wasm"+sdk.PrefixPublic)
-	typesConfig.Seal()
+	params.InitCosmosSdk("wasm", "atom")
 
 	testdir, err := os.MkdirTemp("", "integration-test")
 	require.NoError(t, err)

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -23,7 +23,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/pelletier/go-toml"
-	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/params"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,8 +38,6 @@ var minGasPrice = sdk.NewDecCoinFromDec("ucosm", sdk.NewDecWithPrec(1, 3))
 
 // SetupLocalCosmosNode sets up a local terra node via wasmd, and returns pre-funded accounts, the test directory, and the url.
 func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, string) {
-	params.InitCosmosSdk("wasm", "atom")
-
 	testdir, err := os.MkdirTemp("", "integration-test")
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -41,6 +41,7 @@ func SetupLocalCosmosNode(t *testing.T, chainID string) ([]Account, string, stri
 	// change bech32 prefix from cosmos to wasmd
 	typesConfig := sdk.GetConfig()
 	typesConfig.SetBech32PrefixForAccount("wasm", "wasm"+sdk.PrefixPublic)
+	typesConfig.Seal()
 
 	testdir, err := os.MkdirTemp("", "integration-test")
 	require.NoError(t, err)

--- a/pkg/cosmos/client/test_helpers.go
+++ b/pkg/cosmos/client/test_helpers.go
@@ -165,7 +165,7 @@ func DeployTestContract(t *testing.T, tendermintURL, chainID string, token strin
 	// wait for tx to be committed
 	txHash := gjson.Get(string(submitResp), "txhash")
 	require.True(t, txHash.Exists())
-	storeTx, success := awaitTxCommitted(t, tc, txHash.String())
+	storeTx, success := AwaitTxCommitted(t, tc, txHash.String())
 	require.True(t, success)
 
 	// get code id from tx receipt
@@ -188,7 +188,7 @@ func DeployTestContract(t *testing.T, tendermintURL, chainID string, token strin
 	require.NoError(t, err3)
 
 	// wait for tx to be committed
-	deployTxReceipt, success := awaitTxCommitted(t, tc, deployTx.TxResponse.TxHash)
+	deployTxReceipt, success := AwaitTxCommitted(t, tc, deployTx.TxResponse.TxHash)
 	require.True(t, success)
 
 	return GetContractAddr(t, deployTxReceipt.GetTxResponse())
@@ -219,7 +219,7 @@ func mustRandomPort() int {
 	return int(r.Int64() + 1024)
 }
 
-// awaitTxCommitted waits for a transaction to be committed on chain and returns the tx receipt
+// AwaitTxCommitted waits for a transaction to be committed on chain and returns the tx receipt
 func AwaitTxCommitted(t *testing.T, tc *Client, txHash string) (response *txtypes.GetTxResponse, success bool) {
 	for i := 0; i < 10; i++ { // max poll attempts to wait for tx commitment
 		txReceipt, err := tc.Tx(txHash)


### PR DESCRIPTION
* SetupLocalCosmosNode now takes a token name which determines what staking and fee coin will be used by default
* Made awaiTx method public so it can be used by other go modules