### PR TITLE
Init SDK once per process to avoid client panics

### DIFF
--- a/pkg/cosmos/params/params.go
+++ b/pkg/cosmos/params/params.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -40,7 +41,14 @@ func makeEncodingConfig() encodingConfig {
 // TODO: import as params.MakeEncoding config
 var config = makeEncodingConfig()
 
+var initOnce sync.Once
+
+// Initialize the cosmos sdk at most one time
 func InitCosmosSdk(bech32Prefix, token string) {
+	initOnce.Do(func() { initCosmosSdk(bech32Prefix, token) })
+}
+
+func initCosmosSdk(bech32Prefix, token string) {
 	// copied from wasmd https://github.com/CosmWasm/wasmd/blob/88e01a98ab8a87b98dc26c03715e6aef5c92781b/app/app.go#L163-L174
 	// NOTE: Bech32 is configured globally, blocked on https://github.com/cosmos/cosmos-sdk/issues/13140
 	var (

--- a/pkg/cosmos/params/params_test.go
+++ b/pkg/cosmos/params/params_test.go
@@ -1,0 +1,24 @@
+package params
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitCosmosSdk(t *testing.T) {
+	// sdk initialized only once
+	assert.NotPanics(t, func() { InitCosmosSdk("wasm", "atom") })
+	assert.NotPanics(t, func() { InitCosmosSdk("notwasm", "cosmos") })
+	// calling the internal implementation panics when called a second time
+	assert.Panics(t, func() { initCosmosSdk("wasm", "cosmos") })
+
+	// first call to Init wins
+	sdkConfig := sdk.GetConfig()
+	assert.Equal(t, sdkConfig.GetBech32AccountAddrPrefix(), "wasm")
+	_, ok := sdk.GetDenomUnit("atom")
+	assert.True(t, ok)
+	_, ok = sdk.GetDenomUnit("cosmos")
+	assert.False(t, ok)
+}

--- a/pkg/cosmos/relay.go
+++ b/pkg/cosmos/relay.go
@@ -27,20 +27,6 @@ func (e *ErrMsgUnsupported) Error() string {
 
 var initCosmosOnce sync.Once
 
-// initializing the SDK only once enables callers to instantiate
-// mulitple relayers. needed for BCF-2317
-func init() {
-	// TODO(BCI-915): Make this configurable and relayer-specific
-	// when doing so, core side will have to run each relayer in a LOOPP
-	initCosmosOnce.Do(
-		func() {
-			params.InitCosmosSdk(
-				/* bech32Prefix= */ "wasm",
-				/* token= */ "atom",
-			)
-		})
-}
-
 var _ relaytypes.Relayer = &Relayer{}
 
 type Relayer struct {
@@ -70,6 +56,19 @@ func (r *Relayer) Start(context.Context) error {
 	if r.chainSet == nil {
 		return errors.New("Cosmos unavailable")
 	}
+
+	// initializing the SDK only once enables callers to instantiate
+	// mulitple relayers. needed for BCF-2317. Note that this is buried in
+	// Start to prevent conflicts with other tests
+	// TODO(BCI-915): Make this configurable and relayer-specific
+	// when doing so, core side will have to run each relayer in a LOOPP
+	initCosmosOnce.Do(
+		func() {
+			params.InitCosmosSdk(
+				/* bech32Prefix= */ "wasm",
+				/* token= */ "atom",
+			)
+		})
 
 	return nil
 }

--- a/pkg/cosmos/relay.go
+++ b/pkg/cosmos/relay.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	cosmosSDK "github.com/cosmos/cosmos-sdk/types"
 
@@ -24,8 +23,6 @@ type ErrMsgUnsupported struct {
 func (e *ErrMsgUnsupported) Error() string {
 	return fmt.Sprintf("unsupported message type %T: %s", e.Msg, e.Msg)
 }
-
-var initCosmosOnce sync.Once
 
 var _ relaytypes.Relayer = &Relayer{}
 
@@ -57,18 +54,12 @@ func (r *Relayer) Start(context.Context) error {
 		return errors.New("Cosmos unavailable")
 	}
 
-	// initializing the SDK only once enables callers to instantiate
-	// mulitple relayers. needed for BCF-2317. Note that this is buried in
-	// Start to prevent conflicts with other tests
 	// TODO(BCI-915): Make this configurable and relayer-specific
 	// when doing so, core side will have to run each relayer in a LOOPP
-	initCosmosOnce.Do(
-		func() {
-			params.InitCosmosSdk(
-				/* bech32Prefix= */ "wasm",
-				/* token= */ "atom",
-			)
-		})
+	params.InitCosmosSdk(
+		/* bech32Prefix= */ "wasm",
+		/* token= */ "atom",
+	)
 
 	return nil
 }


### PR DESCRIPTION

Limit the sdk to be initialized once. This is needed to refactor the core to have one relayer per chain, without this change multiple tests try to init the sdk with the same value and this library panics