### PR TITLE
BCI-1796: Support dynamic adapter selection

### DIFF
--- a/.github/workflows/integration-tests-docker.yml
+++ b/.github/workflows/integration-tests-docker.yml
@@ -19,9 +19,7 @@ jobs:
     name: Run docker tests
     runs-on: ubuntu-latest
     env:
-      # TEMP: cosmos-test-keys branch with fixes
-      # TODO: replace with develop when ready
-      DEFAULT_CORE_REF: 9c95732370e5c39a5dccf21e6db9fe167abe8d09
+      DEFAULT_CORE_REF: develop
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Get core ref from PR body

--- a/pkg/cosmos/adapters/injective/relay.go
+++ b/pkg/cosmos/adapters/injective/relay.go
@@ -33,18 +33,14 @@ type configProvider struct {
 	feedID          string
 }
 
-// TODO: pass chain instead of chainSet
-func NewConfigProvider(ctx context.Context, lggr logger.Logger, chainSet adapters.ChainSet, args relaytypes.RelayArgs) (*configProvider, error) {
+func NewConfigProvider(ctx context.Context, lggr logger.Logger, chain adapters.Chain, args relaytypes.RelayArgs) (*configProvider, error) {
 	var relayConfig adapters.RelayConfig
 	err := json.Unmarshal(args.RelayConfig, &relayConfig)
 	if err != nil {
 		return nil, err
 	}
 	feedID := args.ContractID // TODO: probably not bech32
-	chain, err := chainSet.Chain(ctx, relayConfig.ChainID)
-	if err != nil {
-		return nil, err
-	}
+
 	// TODO: share cosmos.Client or extract the inner clientCtx
 	reader, err := chain.Reader(relayConfig.NodeName)
 	if err != nil {
@@ -105,8 +101,8 @@ type medianProvider struct {
 	transmitter types.ContractTransmitter
 }
 
-func NewMedianProvider(ctx context.Context, lggr logger.Logger, chainSet adapters.ChainSet, rargs relaytypes.RelayArgs, pargs relaytypes.PluginArgs) (relaytypes.MedianProvider, error) {
-	configProvider, err := NewConfigProvider(ctx, lggr, chainSet, rargs)
+func NewMedianProvider(ctx context.Context, lggr logger.Logger, chain adapters.Chain, rargs relaytypes.RelayArgs, pargs relaytypes.PluginArgs) (relaytypes.MedianProvider, error) {
+	configProvider, err := NewConfigProvider(ctx, lggr, chain, rargs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosmos/relay.go
+++ b/pkg/cosmos/relay.go
@@ -115,6 +115,8 @@ func (r *Relayer) NewConfigProvider(args relaytypes.RelayArgs) (relaytypes.Confi
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		return nil, fmt.Errorf("unrecognized cosmos chain type: %s", r.cosmosChainType)
 	}
 
 	return configProvider, err


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCI-1796

This PR adds support for dynamically selecting the Cosmos adapter (currently only cosmos and injective) based on the bech32 prefix of the chain.