### PR TITLE
BCF-2440: rm chainset

### DIFF
--- a/pkg/cosmos/adapters/chain.go
+++ b/pkg/cosmos/adapters/chain.go
@@ -7,8 +7,6 @@ import (
 	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/config"
 )
 
-type ChainSet = types.ChainSet[string, Chain]
-
 type Chain interface {
 	types.ChainService
 


### PR DESCRIPTION
The corresponding ticket in the core repo removed all ChainSet deps. We can delete it here.