### PR TITLE
BCI-1511: Fix Gauntlet Upload -- update schema dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.5"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a227cfeb9a7152b26a354b1c990e930e962f75fd68f57ab5ae2ef888c8524292"
+checksum = "99222fa0401ee36389550d8a065700380877a2299c3043d24c38d705708c9d9d"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.5"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3626cb42eef870de67f791e873711255325224d86f281bf628c42abd295f3a14"
+checksum = "4b74eaf9e585ef8e5e3486b240b13ee593cb0f658b5879696937d8c22243d4fb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contracts/access-controller/Cargo.toml
+++ b/contracts/access-controller/Cargo.toml
@@ -22,7 +22,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-schema = { version = "1.1.5" }
+cosmwasm-schema = { version = "1.3.1" }
 cosmwasm-std = { version = "1.1.5" }
 cosmwasm-storage = { version = "1.1.5" }
 cw-storage-plus = "0.16.0"

--- a/contracts/flags/Cargo.toml
+++ b/contracts/flags/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
 owned = { version = "1.0", path = "../../crates/owned", default-features = false }
 access-controller = { version = "1.0", path = "../access-controller", default-features = false, features = ["library"] }
-cosmwasm-schema = { version = "1.1.5" }
+cosmwasm-schema = { version = "1.3.1" }
 
 [dev-dependencies]
 cw-multi-test = "0.16.0"

--- a/contracts/flags/schema/flags.json
+++ b/contracts/flags/schema/flags.json
@@ -147,10 +147,10 @@
       {
         "type": "object",
         "required": [
-          "Owner"
+          "owner"
         ],
         "properties": {
-          "Owner": {
+          "owner": {
             "type": "object"
           }
         },
@@ -159,10 +159,10 @@
       {
         "type": "object",
         "required": [
-          "Flag"
+          "flag"
         ],
         "properties": {
-          "Flag": {
+          "flag": {
             "type": "object",
             "required": [
               "subject"
@@ -179,10 +179,10 @@
       {
         "type": "object",
         "required": [
-          "Flags"
+          "flags"
         ],
         "properties": {
-          "Flags": {
+          "flags": {
             "type": "object",
             "required": [
               "subjects"
@@ -202,10 +202,10 @@
       {
         "type": "object",
         "required": [
-          "RaisingAccessController"
+          "raising_access_controller"
         ],
         "properties": {
-          "RaisingAccessController": {
+          "raising_access_controller": {
             "type": "object"
           }
         },

--- a/contracts/flags/src/msg.rs
+++ b/contracts/flags/src/msg.rs
@@ -36,6 +36,7 @@ pub enum ExecuteMsg {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema, QueryResponses)]
+#[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     #[returns(Addr)]
     Owner {},

--- a/contracts/ocr2/Cargo.toml
+++ b/contracts/ocr2/Cargo.toml
@@ -35,7 +35,7 @@ hex = "0.4.3"
 access-controller = { version = "1.0", path = "../access-controller", default-features = false, features = ["library"] }
 deviation-flagging-validator = { version = "1.0", path = "../deviation-flagging-validator", default-features = false, features = ["library"] }
 owned = { version = "1.0", path = "../../crates/owned" }
-cosmwasm-schema = { version = "1.1.5" }
+cosmwasm-schema = { version = "1.3.1" }
 
 [dev-dependencies]
 ed25519-zebra = "3.0.0"

--- a/contracts/proxy-ocr2/Cargo.toml
+++ b/contracts/proxy-ocr2/Cargo.toml
@@ -15,7 +15,7 @@ library = []
 [dependencies]
 ocr2 = { path = "../ocr2", default-features = false, features = ["library"] }
 owned = { version = "1.0", path = "../../crates/owned" }
-cosmwasm-schema = { version = "1.1.5" }
+cosmwasm-schema = { version = "1.3.1" }
 cosmwasm-std = { version = "1.1.5" }
 cosmwasm-storage = { version = "1.1.5" }
 cw-storage-plus = "0.16.0"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -26,5 +26,5 @@ thiserror = { version = "1.0.24" }
 chainlink-cosmos = { version = "1.0", package = "proxy-ocr2", path = "../../contracts/proxy-ocr2", default-features = false, features = ["library"] }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.1.5" }
+cosmwasm-schema = { version = "1.3.1" }
 cw-multi-test = "0.16.0"

--- a/integration-tests/ocr2_test.go
+++ b/integration-tests/ocr2_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/params"
 	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/testutil"
 	relaylogger "github.com/smartcontractkit/chainlink-relay/pkg/logger"
+
 	// "github.com/smartcontractkit/chainlink/integration-tests/actions"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 
@@ -216,7 +217,7 @@ func validateRounds(t *testing.T, cosmosClient *client.Client, ocrAddress types.
 	var positive bool
 	resp, err := cosmosClient.ContractState(
 		ocrAddress,
-		[]byte(`"link_available_for_payment"`),
+		[]byte(`{"link_available_for_payment":{}}`),
 	)
 	if err != nil {
 		return err
@@ -329,7 +330,7 @@ func validateRounds(t *testing.T, cosmosClient *client.Client, ocrAddress types.
 
 	// Test proxy reading
 	// TODO: would be good to test proxy switching underlying feeds
-	resp, err = cosmosClient.ContractState(ocrProxyAddress, []byte(`"latest_round_data"`))
+	resp, err = cosmosClient.ContractState(ocrProxyAddress, []byte(`{"latest_round_data":{}}`))
 	if !isSoak {
 		require.NoError(t, err, "Reading round data from proxy should not fail")
 		//assert.Equal(t, len(roundDataRaw), 5, "Round data from proxy should match expected size")

--- a/packages-ts/gauntlet-cosmos-contracts/src/commands/contracts/ocr2/withdrawFunds.ts
+++ b/packages-ts/gauntlet-cosmos-contracts/src/commands/contracts/ocr2/withdrawFunds.ts
@@ -30,7 +30,8 @@ const makeCommandInput = async (flags: any, args: string[]): Promise<CommandInpu
 
 const makeContractInput = async (input: CommandInput, context: ExecutionContext): Promise<ContractInput> => {
   const queryAvailableLink = async () =>
-    ((await context.provider.queryContractSmart(context.contract, 'link_available_for_payment' as any)) as any).amount
+    ((await context.provider.queryContractSmart(context.contract, { link_available_for_payment: {} } as any)) as any)
+      .amount
   const amount = input.all ? await queryAvailableLink() : input.amount
   const recipient = input.recipient || context.signer.address
   return {

--- a/packages-ts/gauntlet-cosmos-contracts/src/lib/contracts.ts
+++ b/packages-ts/gauntlet-cosmos-contracts/src/lib/contracts.ts
@@ -95,17 +95,11 @@ export abstract class Contract {
     const abi = possibleContractPaths
       .filter((path) => existsSync(`${path}/${this.dirName}/schema`))
       .map((contractPath) => {
-        const toPath = (type) => {
-          if (this.id == CONTRACT_LIST.CW20_BASE && type == 'execute_msg') {
-            return path.join(contractPath, `./${this.dirName}/schema/cw20_${type}`)
-          } else {
-            return path.join(contractPath, `./${this.dirName}/schema/${type}`)
-          }
-        }
+        const toPath = (type) => path.join(contractPath, `./${this.dirName}/schema/raw/${type}`)
         return {
-          execute: io.readJSON(toPath('execute_msg')),
-          query: io.readJSON(toPath('query_msg')),
-          instantiate: io.readJSON(toPath('instantiate_msg')),
+          execute: io.readJSON(toPath('execute')),
+          query: io.readJSON(toPath('query')),
+          instantiate: io.readJSON(toPath('instantiate')),
         }
       })
     if (abi.length === 0) {

--- a/packages-ts/gauntlet-cosmos-contracts/src/lib/inspection.ts
+++ b/packages-ts/gauntlet-cosmos-contracts/src/lib/inspection.ts
@@ -13,7 +13,7 @@ export type RoundData = {
 // TODO: find the right place for this function
 export const getLatestOCRConfigEvent = async (provider: Client, contract: AccAddress) => {
   // The contract only stores the block where the config was accepted. The tx log contains the config
-  const latestConfigDetails: any = await provider.queryContractSmart(contract, 'latest_config_details' as any)
+  const latestConfigDetails: any = await provider.queryContractSmart(contract, { latest_config_details: {} } as any)
   const setConfigTx = providerUtils.filterTxsByEvent(
     // TODO: there has to be a way to filter by tag for event then scan single block
     await provider.searchTx(`tx.height=${latestConfigDetails.block_number}`),

--- a/pkg/cosmos/adapters/cosmwasm/contract_reader.go
+++ b/pkg/cosmos/adapters/cosmwasm/contract_reader.go
@@ -35,7 +35,7 @@ func NewOCR2Reader(addess cosmosSDK.AccAddress, chainReader client.Reader, lggr 
 func (r *OCR2Reader) LatestConfigDetails(ctx context.Context) (changedInBlock uint64, configDigest types.ConfigDigest, err error) {
 	resp, err := r.chainReader.ContractState(
 		r.address,
-		[]byte(`"latest_config_details"`),
+		[]byte(`{"latest_config_details":{}}`),
 	)
 	if err != nil {
 		return
@@ -228,7 +228,7 @@ func (r *OCR2Reader) LatestTransmissionDetails(ctx context.Context) (
 	latestTimestamp time.Time,
 	err error,
 ) {
-	resp, err := r.chainReader.ContractState(r.address, []byte(`"latest_transmission_details"`))
+	resp, err := r.chainReader.ContractState(r.address, []byte(`{"latest_transmission_details":{}}`))
 	if err != nil {
 		// Handle the 500 error that occurs when there has not been a submission
 		// "rpc error: code = Unknown desc = ocr2::state::Transmission not found: contract query failed: unknown request"
@@ -338,7 +338,7 @@ func (r *OCR2Reader) LatestConfigDigestAndEpoch(ctx context.Context) (
 	err error,
 ) {
 	resp, err := r.chainReader.ContractState(
-		r.address, []byte(`"latest_config_digest_and_epoch"`),
+		r.address, []byte(`{"latest_config_digest_and_epoch":{}}`),
 	)
 	if err != nil {
 		return types.ConfigDigest{}, 0, err

--- a/pkg/monitoring/proxy_monitoring_test.go
+++ b/pkg/monitoring/proxy_monitoring_test.go
@@ -45,7 +45,7 @@ func TestProxyMonitoring(t *testing.T) {
 		chainReader.On("ContractState",
 			mock.Anything, // context
 			feedConfig.ProxyAddress,
-			[]byte(`"latest_round_data"`),
+			[]byte(`{"latest_round_data":{}}`),
 		).Return(
 			[]byte(`{"round_id":5709,"answer":"2632212500","observations_timestamp":1645456354,"transmission_timestamp":1645456380}`),
 			nil,

--- a/pkg/monitoring/source_envelope.go
+++ b/pkg/monitoring/source_envelope.go
@@ -249,7 +249,7 @@ func (e *envelopeSource) fetchLatestConfigBlock(ctx context.Context) (uint64, er
 	resp, err := e.rpcClient.ContractState(
 		ctx,
 		e.cosmosFeedConfig.ContractAddress,
-		[]byte(`"latest_config_details"`),
+		[]byte(`{"latest_config_details":{}}`),
 	)
 	var details cosmwasm.ConfigDetails
 	if err != nil {
@@ -352,7 +352,7 @@ func (e *envelopeSource) fetchLinkAvailableForPayment(ctx context.Context) (*big
 	res, err := e.rpcClient.ContractState(
 		ctx,
 		e.cosmosFeedConfig.ContractAddress,
-		[]byte(`"link_available_for_payment"`),
+		[]byte(`{"link_available_for_payment":{}}`),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read link_available_for_payment from the contract: %w", err)

--- a/pkg/monitoring/source_envelope_test.go
+++ b/pkg/monitoring/source_envelope_test.go
@@ -55,7 +55,7 @@ func TestEnvelopeSource(t *testing.T) {
 	rpcClient.On("ContractState",
 		mock.Anything, // context
 		feedConfig.ContractAddress,
-		[]byte(`"latest_config_details"`),
+		[]byte(`{"latest_config_details":{}}`),
 	).Return(latestConfigDetailsRes, nil).Once()
 	fcdClient.On("GetBlockAtHeight",
 		mock.Anything,   // context
@@ -71,7 +71,7 @@ func TestEnvelopeSource(t *testing.T) {
 	rpcClient.On("ContractState",
 		mock.Anything, // context
 		feedConfig.ContractAddress,
-		[]byte(`"link_available_for_payment"`),
+		[]byte(`{"link_available_for_payment":{}}`),
 	).Return(linkAvailableForPaymentRes, nil).Once()
 
 	// Execute Fetch()
@@ -170,7 +170,7 @@ func TestEnvelopeSource(t *testing.T) {
 	rpcClient.On("ContractState",
 		mock.Anything, // context
 		feedConfig.ContractAddress,
-		[]byte(`"link_available_for_payment"`),
+		[]byte(`{"link_available_for_payment":{}}`),
 	).Return(linkAvailableForPaymentRes, nil).Once()
 
 	// Execute second Fetch()

--- a/pkg/monitoring/source_proxy.go
+++ b/pkg/monitoring/source_proxy.go
@@ -76,7 +76,7 @@ func (p *proxySource) fetchLatestRoundFromProxy(ctx context.Context) (*big.Int, 
 	res, err := p.client.ContractState(
 		ctx,
 		p.cosmosFeedConfig.ProxyAddress,
-		[]byte(`"latest_round_data"`),
+		[]byte(`{"latest_round_data":{}}`),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read latest_round_data from the proxy contract: %w", err)


### PR DESCRIPTION
fixes bug where `yarn gauntlet upload` could not find the name of the json message apis 

Was kind of a tricky bug to track down but it turns out that this branch was using an outdated version of cosmwasm-schema crate which didn't output some of the schema files. So when make contracts_compile was ran, the schema files were regenerated incorrectly. 

Some other stuff was in a broken state so I had to pick out other schema / go-related / ts changes from https://github.com/smartcontractkit/chainlink-cosmos/pull/364  that are either necessary for this PR to run successfully