### PR TITLE
BCI-1962: Add gas price to OCR reports in contracts

### DIFF
--- a/contracts/ocr2/src/contract.rs
+++ b/contracts/ocr2/src/contract.rs
@@ -911,7 +911,8 @@ fn decode_report(raw_report: &[u8]) -> Result<Report, ContractError> {
 
     // assert the remainder of the report is long enough for N observations + juels_per_fee_coin + gas_price
     require!(
-        raw_report.len() == OBSERVATION_SIZE * len + mem::size_of::<u128>() + mem::size_of::<u128>(),
+        raw_report.len()
+            == OBSERVATION_SIZE * len + mem::size_of::<u128>() + mem::size_of::<u128>(),
         InvalidInput
     );
 
@@ -1722,8 +1723,10 @@ pub(crate) mod tests {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 2
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 3
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 4
-        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, // juels per atom (1 with 18 decimal places)
-        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, // gas price (1 with 18 decimal places)
+        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0,
+        0, // juels per atom (1 with 18 decimal places)
+        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0,
+        0, // gas price (1 with 18 decimal places)
     ];
 
     #[test]

--- a/contracts/ocr2/src/contract.rs
+++ b/contracts/ocr2/src/contract.rs
@@ -875,6 +875,7 @@ struct Report {
     pub observers: [u8; MAX_ORACLES], // observer index
     pub observations_timestamp: u32,
     pub juels_per_fee_coin: u128,
+    pub gas_price: u128,
 }
 
 // NOTE: unwraps in this method can be factored out once split_array is stable
@@ -908,9 +909,9 @@ fn decode_report(raw_report: &[u8]) -> Result<Report, ContractError> {
 
     const OBSERVATION_SIZE: usize = mem::size_of::<i128>();
 
-    // assert the remainder of the report is long enough for N observations + juels_per_fee_coin
+    // assert the remainder of the report is long enough for N observations + juels_per_fee_coin + gas_price
     require!(
-        raw_report.len() == OBSERVATION_SIZE * len + mem::size_of::<u128>(),
+        raw_report.len() == OBSERVATION_SIZE * len + mem::size_of::<u128>() + mem::size_of::<u128>(),
         InvalidInput
     );
 
@@ -921,7 +922,15 @@ fn decode_report(raw_report: &[u8]) -> Result<Report, ContractError> {
         .collect::<Vec<_>>();
 
     // juels per atom = u128
+    let (raw_juels_per_fee_coin, raw_report) = raw_report.split_at(16);
     let juels_per_fee_coin = u128::from_be_bytes(
+        raw_juels_per_fee_coin
+            .try_into()
+            .map_err(|_| ContractError::InvalidInput)?,
+    );
+
+    // gas_price = u128
+    let gas_price = u128::from_be_bytes(
         raw_report
             .try_into()
             .map_err(|_| ContractError::InvalidInput)?,
@@ -932,6 +941,7 @@ fn decode_report(raw_report: &[u8]) -> Result<Report, ContractError> {
         observers,
         observations_timestamp,
         juels_per_fee_coin,
+        gas_price,
     })
 }
 
@@ -992,6 +1002,7 @@ fn report(
                 ),
                 attr("observers", hex::encode(report.observers)),
                 attr("juels_per_fee_coin", report.juels_per_fee_coin.to_string()),
+                attr("gas_price", report.gas_price.to_string()),
                 attr("config_digest", hex::encode(config_digest)),
                 attr("epoch", config.epoch.to_string()),
                 attr("round", config.round.to_string()),
@@ -1711,8 +1722,8 @@ pub(crate) mod tests {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 2
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 3
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 4
-        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0,
-        0, // juels per atom (1 with 18 decimal places)
+        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, // juels per atom (1 with 18 decimal places)
+        0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, // gas price (1 with 18 decimal places)
     ];
 
     #[test]

--- a/contracts/ocr2/src/integration_tests.rs
+++ b/contracts/ocr2/src/integration_tests.rs
@@ -107,6 +107,7 @@ fn transmit_report(
         report.extend_from_slice(&bytes); // observation
     }
     report.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0]); // juels per atom (1 with 18 decimal places)
+    report.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0]); // gas_price (1 with 18 decimal places)
 
     // Generate report context
     let mut report_context = vec![0; 96];

--- a/contracts/ocr2/tests/integration.rs
+++ b/contracts/ocr2/tests/integration.rs
@@ -47,7 +47,10 @@ pub const REPORT2: &[u8] = &[
     2, // len
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 1
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 2
-    0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, // juels per atom (1 with 18 decimal places)
+    0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0,
+    0, // juels per atom (1 with 18 decimal places)
+    0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0,
+    0, // gas price (1 with 18 decimal places)
 ];
 
 #[test]

--- a/contracts/ocr2/tests/integration.rs
+++ b/contracts/ocr2/tests/integration.rs
@@ -47,8 +47,7 @@ pub const REPORT2: &[u8] = &[
     2, // len
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 1
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210, // observation 2
-    0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0,
-    0, // juels per atom (1 with 18 decimal places)
+    0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0, // juels per atom (1 with 18 decimal places)
 ];
 
 #[test]
@@ -187,6 +186,8 @@ fn gas_test() {
         report.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210]);
     }
     // juels per atom (1 with 18 decimal places)
+    report.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0]);
+    // gas price (1 with 18 decimal places)
     report.extend_from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0]);
 
     let mut report_context = vec![0; 96];

--- a/pkg/cosmos/adapters/cosmwasm/contract_transmitter.go
+++ b/pkg/cosmos/adapters/cosmwasm/contract_transmitter.go
@@ -3,6 +3,7 @@ package cosmwasm
 import (
 	"context"
 	"encoding/json"
+	"math/big"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	cosmosSDK "github.com/cosmos/cosmos-sdk/types"
@@ -60,7 +61,10 @@ func (ct *ContractTransmitter) Transmit(
 	for _, r := range reportContext {
 		msgStruct.Transmit.ReportContext = append(msgStruct.Transmit.ReportContext, r[:]...)
 	}
-	msgStruct.Transmit.Report = []byte(report)
+	// TODO: This temporarily appends a dummy gas price to the report.
+	// When core/relayer is updated to support adding gas price to the report, we can remove this
+	dummyGasPrice := new(big.Int).SetUint64(1).Bytes()
+	msgStruct.Transmit.Report = append([]byte(report), dummyGasPrice...)
 	for _, sig := range sigs {
 		msgStruct.Transmit.Signatures = append(msgStruct.Transmit.Signatures, sig.Signature)
 	}

--- a/pkg/cosmos/adapters/cosmwasm/contract_transmitter.go
+++ b/pkg/cosmos/adapters/cosmwasm/contract_transmitter.go
@@ -74,10 +74,20 @@ func (ct *ContractTransmitter) Transmit(
 	}
 	// TODO: This temporarily appends a dummy gas price to the report.
 	// When core/relayer is updated to support adding gas price to the report, we can remove this
-	dummyGasPrice_u128 := Uint128{Lo: 1, Hi: 0}
-	dummyGasPrice := make([]byte, 16)
-	dummyGasPrice_u128.Bytes(dummyGasPrice)
-	msgStruct.Transmit.Report = append([]byte(report), dummyGasPrice...)
+	// dummyGasPrice_u128 := Uint128{Lo: 1, Hi: 0}
+	// dummyGasPrice := make([]byte, 16)
+	// dummyGasPrice_u128.Bytes(dummyGasPrice)
+	// msgStruct.Transmit.Report = append([]byte(report), dummyGasPrice...)
+
+	dummyReport := []byte{97, 91, 43, 83}                                                                                                        // observationTimestamp
+	dummyReport = append(dummyReport, []byte{0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}...) // observers
+	dummyReport = append(dummyReport, 2)                                                                                                         // observationLen
+	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210}...)                                            // observation1
+	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210}...)                                            // observation2
+	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0}...)                                      // juelsPerFeeCoin
+	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0}...)                                      // gasPrice
+	msgStruct.Transmit.Report = dummyReport
+
 	for _, sig := range sigs {
 		msgStruct.Transmit.Signatures = append(msgStruct.Transmit.Signatures, sig.Signature)
 	}

--- a/pkg/cosmos/adapters/cosmwasm/contract_transmitter.go
+++ b/pkg/cosmos/adapters/cosmwasm/contract_transmitter.go
@@ -72,21 +72,6 @@ func (ct *ContractTransmitter) Transmit(
 	for _, r := range reportContext {
 		msgStruct.Transmit.ReportContext = append(msgStruct.Transmit.ReportContext, r[:]...)
 	}
-	// TODO: This temporarily appends a dummy gas price to the report.
-	// When core/relayer is updated to support adding gas price to the report, we can remove this
-	// dummyGasPrice_u128 := Uint128{Lo: 1, Hi: 0}
-	// dummyGasPrice := make([]byte, 16)
-	// dummyGasPrice_u128.Bytes(dummyGasPrice)
-	// msgStruct.Transmit.Report = append([]byte(report), dummyGasPrice...)
-
-	dummyReport := []byte{97, 91, 43, 83}                                                                                                        // observationTimestamp
-	dummyReport = append(dummyReport, []byte{0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}...) // observers
-	dummyReport = append(dummyReport, 2)                                                                                                         // observationLen
-	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210}...)                                            // observation1
-	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 73, 150, 2, 210}...)                                            // observation2
-	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0}...)                                      // juelsPerFeeCoin
-	dummyReport = append(dummyReport, []byte{0, 0, 0, 0, 0, 0, 0, 0, 13, 224, 182, 179, 167, 100, 0, 0}...)                                      // gasPrice
-	msgStruct.Transmit.Report = dummyReport
 
 	for _, sig := range sigs {
 		msgStruct.Transmit.Signatures = append(msgStruct.Transmit.Signatures, sig.Signature)


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCI-1962
(more context in https://smartcontract-it.atlassian.net/browse/BCI-1966)

Cosmos doesn't have an on-chain way of getting the gas price so we need to include the gas price as an additional field in the report

note: integration tests currently fail as this requires a change to the ocr report and core node to support the gas price param, which is in progress here - https://github.com/smartcontractkit/chainlink/pull/10489. Submitting a dummy gas price value to pass e2e tests in the meantime doesn't work as this modifies the ocr report and therefore fails signature checks on chain