### PR TITLE
standardize make gomodtidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ build-go-integration-tests:
 	cd integration-tests/ && go build ./...
 
 .PHONY: format-go
-format-go: format-go-fmt format-go-mod-tidy
+format-go: format-go-fmt gomodtidy
 
 .PHONY: format-go-fmt
 format-go-fmt:
@@ -130,8 +130,8 @@ format-go-fmt:
 	cd ./ops && go fmt ./...
 	cd ./integration-tests && go fmt ./...
 
-.PHONY: format-go-mod-tidy
-format-go-mod-tidy:
+.PHONY: gomodtidy
+gomodtidy:
 	go mod tidy
 	cd ./ops && go mod tidy
 	cd ./integration-tests && go mod tidy


### PR DESCRIPTION
standardizing to what core and solana use:
https://github.com/smartcontractkit/chainlink/blob/b3ec54a83df3a56d6aa399d2f783c64dabe1920c/GNUmakefile#L30
https://github.com/smartcontractkit/chainlink-solana/blob/111b7c0fe59257650617c3c9e26a8f411fe29214/Makefile#L91