### PR TITLE
Adding NewCCIPCommitProvider + NewCCIPExecProvider to relay

### DIFF
--- a/pkg/cosmos/relay.go
+++ b/pkg/cosmos/relay.go
@@ -135,3 +135,11 @@ func (r *Relayer) NewOCR3CapabilityProvider(rargs types.RelayArgs, pargs types.P
 func (r *Relayer) NewContractReader(_ []byte) (types.ContractReader, error) {
 	return nil, errors.New("contract reader is not supported for cosmos")
 }
+
+func (r *Relayer) NewCCIPCommitProvider(rargs types.RelayArgs, pargs types.PluginArgs) (types.CCIPCommitProvider, error) {
+	return nil, errors.New("ccip.commit is not supported for cosmos")
+}
+
+func (r *Relayer) NewCCIPExecProvider(rargs types.RelayArgs, pargs types.PluginArgs) (types.CCIPExecProvider, error) {
+	return nil, errors.New("ccip.exec is not supported for cosmos")
+}


### PR DESCRIPTION
Cascaded from [smartcontractkit/ccip#938 (files)](https://github.com/smartcontractkit/ccip/pull/938/files#top), and getting ahead of what we'll need for the CCIP Exec provider implementation as well.