### PR TITLE
pkg/cosmos: close chain from relayer

### DIFF
--- a/pkg/cosmos/relay.go
+++ b/pkg/cosmos/relay.go
@@ -60,7 +60,7 @@ func (r *Relayer) Start(ctx context.Context) error {
 	return r.chain.Start(ctx)
 }
 
-func (r *Relayer) Close() error { return nil }
+func (r *Relayer) Close() error { return r.chain.Close() }
 
 func (r *Relayer) Ready() error {
 	return r.chain.Ready()


### PR DESCRIPTION
This leak was noticed in core test failures:
```
TestShell_SendCosmosCoins (36.58s) 
panic: Log in goroutine after TestShell_SendCosmosCoins has completed
```

core ref: 7a311a7bf77db21006ac141fbed10308b52828a1