### PR TITLE
fix(cosmos): avoid "codec sealed" panic in injective proposal registration

### DIFF
--- a/pkg/cosmos/adapters/injective/types/proposal.go
+++ b/pkg/cosmos/adapters/injective/types/proposal.go
@@ -13,8 +13,9 @@ const (
 
 func init() {
 	gov.RegisterProposalType(ProposalTypeOcrSetConfig)
-	amino.RegisterConcrete(&SetConfigProposal{}, "injective/OcrSetConfigProposal", nil)
-	amino.RegisterConcrete(&SetBatchConfigProposal{}, "injective/OcrSetBatchConfigProposal", nil)
+	// Keep Amino concrete registration out of this init. The package-level
+	// LegacyAmino in codec.go is sealed during init, and registering here can
+	// trigger "panic: codec sealed" depending on init order.
 }
 
 // Implements Proposal Interface

--- a/pkg/cosmos/adapters/injective/types/proposal_regression_test.go
+++ b/pkg/cosmos/adapters/injective/types/proposal_regression_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+)
+
+func TestProposalTypeRegistered(t *testing.T) {
+	t.Parallel()
+
+	if !gov.IsValidProposalType(ProposalTypeOcrSetConfig) {
+		t.Fatalf("proposal type %q is not registered", ProposalTypeOcrSetConfig)
+	}
+}
+
+func TestSetConfigProposalAminoRegistration(t *testing.T) {
+	t.Parallel()
+
+	var content gov.Content = &SetConfigProposal{
+		Title:       "title",
+		Description: "description",
+	}
+
+	bz, err := amino.MarshalJSON(content)
+	if err != nil {
+		t.Fatalf("marshal gov.Content via amino: %v", err)
+	}
+
+	if !strings.Contains(string(bz), "ocr/SetConfigProposal") {
+		t.Fatalf("expected amino type tag to include ocr/SetConfigProposal, got: %s", string(bz))
+	}
+}
+
+func TestLegacyAminoRegistrationPanicsAfterSeal(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when registering on sealed legacy amino codec")
+		}
+		if !strings.Contains(fmt.Sprint(r), "codec sealed") {
+			t.Fatalf("expected panic to contain %q, got: %v", "codec sealed", r)
+		}
+	}()
+
+	amino.RegisterConcrete(&SetConfigProposal{}, "injective/OcrSetConfigProposal", nil)
+}


### PR DESCRIPTION
## Summary
Fixes Injective plugin startup panic: `panic: codec sealed`.

## Root Cause
`cosmos-sdk` upgrade (`v0.50.x`) changed codec expectations, and proposal Amino registration was moved to module-local `amino` in `proposal.go`.  
That codec is sealed in `codec.go`, so later `RegisterConcrete(...)` calls panic.

## Changes
- Removed duplicate `amino.RegisterConcrete(...)` calls from `proposal.go` init.
- Kept `gov.RegisterProposalType(...)`.
- Added regression tests for:
  - proposal type registration
  - proposal Amino type tagging
  - sealed-codec panic behavior

## Why safe
Proposal concrete registration is still done in `RegisterLegacyAminoCodec(...)` (`codec.go`), so functionality is preserved while removing the unsafe registration path.

## Validation
- `go test ./pkg/cosmos/adapters/injective/types` passes
- Plugin no longer panics with `codec sealed` on startup