### PR TITLE
chore(IP-3479): remove unused bitnami helm repository

### DIFF
--- a/helm-repositories.yaml
+++ b/helm-repositories.yaml
@@ -5,15 +5,6 @@ repositories:
     certFile: ''
     insecure_skip_tls_verify: false
     keyFile: ''
-    name: bitnami
-    pass_credentials_all: false
-    password: ''
-    url: https://charts.bitnami.com/bitnami
-    username: ''
-  - caFile: ''
-    certFile: ''
-    insecure_skip_tls_verify: false
-    keyFile: ''
     name: chainlink-qa
     pass_credentials_all: false
     password: ''


### PR DESCRIPTION
## What

remove the unused Bitnami Helm repository from `helm-repositories.yaml`

ticket: https://smartcontract-it.atlassian.net/browse/IP-3479

## Why

deprecating bitnami images and charts due to licensing/cost impact